### PR TITLE
Change en/decrypt to en/decode in multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Find the new repository here: [Cryptii/Cryptii](https://github.com/Cryptii/Crypt
 Cryptii
 =======
 Don't leave your messages plaintext on public places.
-Cryptii is an OpenSource web application under the MIT license where you can convert, encrypt and decrypt content between different format systems.
+Cryptii is an OpenSource web application under the MIT license where you can convert, encode and decode content between different format systems.
 This happens fully in your browser using JavaScript, no content will be sent to any kind of server.
 In addition, you can download and use this web app offline as described below.
 Any feedback appreciated, just leave me a tweet or contribute to this project.

--- a/local.html
+++ b/local.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 
-		<title>Fast converting, encrypting and decrypting — Cryptii</title>
+		<title>Fast converting, encoding and decoding — Cryptii</title>
 
 		<link rel="shortcut icon" type="image/x-icon" href="images/favicon.ico">
 		<link rel="stylesheet" href="css/default.css" media="screen">
@@ -40,7 +40,7 @@
 					Don't leave your messages plaintext on public places.
 					Cryptii is an OpenSource web application under the
 					<a href="https://github.com/the2f/Cryptii#license" target="_blank">MIT license</a>
-					where you can convert, encrypt and decrypt content between different format systems.
+					where you can convert, encode and decode content between different format systems.
 					This happens fully in your browser using
 					<a href="http://en.wikipedia.org/wiki/JavaScript" target="_blank">JavaScript</a>,
 					no content will be sent to any kind of server.

--- a/source.html
+++ b/source.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 
-		<title>Fast converting, encrypting and decrypting — Cryptii</title>
+		<title>Fast converting, encoding and decoding — Cryptii</title>
 
 		<link rel="shortcut icon" type="image/x-icon" href="images/favicon.ico">
 		<link rel="stylesheet" href="css/default.css" media="screen">
@@ -40,7 +40,7 @@
 					Don't leave your messages plaintext on public places.
 					Cryptii is an OpenSource web application under the
 					<a href="https://github.com/the2f/Cryptii#license" target="_blank">MIT license</a>
-					where you can convert, encrypt and decrypt content between different format systems.
+					where you can convert, encode and decode content between different format systems.
 					This happens fully in your browser using
 					<a href="http://en.wikipedia.org/wiki/JavaScript" target="_blank">JavaScript</a>,
 					no content will be sent to any kind of server.


### PR DESCRIPTION
Changed typo where encrypt and decrypt were used when encoding and decoding were meant to be used. Commits done with github.com interface which seems to want one commit per file changed, hence multiple commits.